### PR TITLE
fix: remove all extra log handlers

### DIFF
--- a/unstructured_ingest/v2/logger.py
+++ b/unstructured_ingest/v2/logger.py
@@ -112,14 +112,7 @@ def remove_root_handlers(logger: Logger) -> None:
 def make_default_logger(level: int) -> Logger:
     """Return a custom logger."""
     logger = getLogger(LOGGER_NAME)
-    handler = StreamHandler()
-    handler.name = "ingest_log_handler"
-    formatter = SensitiveFormatter("%(asctime)s %(processName)-10s %(levelname)-8s %(message)s")
-    handler.setFormatter(formatter)
-    if handler.name not in [h.name for h in logger.handlers]:
-        logger.addHandler(handler)
     logger.setLevel(level)
-    # remove_root_handlers(logger)
     return logger
 
 


### PR DESCRIPTION
removes all code that leads to duplicate logs (1 slog and 1 normal log). Also removes commented out root log handler overwriting.

Signed-off-by: Max Newcomer <maxwnewcomer@gmail.com>
